### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
-init:
-	pip install -r requirements.txt
+.PHONY: all
+all: test
 
-test:
+.PHONY: init
+init: .pip_install_timestamp
+.pip_install_timestamp: requirements.txt
+	pip install -r requirements.txt
+	touch .pip_install_timestamp
+
+.PHONY: test
+test: .pip_install_timestamp
 	nosetests tests


### PR DESCRIPTION
non-file targets should be .PHONY. The default target should be to run the tests, not to install the requirements. The default target should be all. Requirements should be installed automatically if not installed yet or out of date.